### PR TITLE
added tests for book delete

### DIFF
--- a/books/tests/test_views.py
+++ b/books/tests/test_views.py
@@ -93,6 +93,10 @@ class AuthenticatedBookApiTests(TestCase):
         response = self.client.patch(self.detail_url, data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_cannot_delete_book(self):
+        response = self.client.delete(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
 
 class StaffBookApiTests(TestCase):
     def setUp(self):
@@ -182,3 +186,8 @@ class StaffBookApiTests(TestCase):
         response = self.client.put(self.detail_url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("non_field_errors", response.data)
+
+    def test_staff_can_delete_book(self):
+        response = self.client.delete(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Book.objects.count(), 0)


### PR DESCRIPTION
Implement the DELETE /books/<id>/ endpoint, restricted to staff users only. Add tests to confirm that staff can successfully delete a book, while non-staff users receive a forbidden response.